### PR TITLE
refactor: markdown-it app.use でグローバルに登録するのをやめた

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,7 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import router from './router'
 import App from './App.vue'
-import MarkDown from 'vue3-markdown-it'
 
 import './styles/index.scss'
 
-createApp(App).use(router).use(createPinia()).use(MarkDown).mount('#app')
+createApp(App).use(router).use(createPinia()).mount('#app')


### PR DESCRIPTION
コンポーネント単位で import すればよい