### PR TITLE
ci: npm run build 前に .env を作成するようにした

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: |
+          touch .env
+          echo "VITE_API_BASE=$VITE_API_BASE" >> .env
+        env:
+          VITE_API_BASE: ${{secrets.VITE_API_BASE}}
       - run: npm ci && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
一旦テスト

これで環境変数 `VITE_API_BASE` がワークフロー内で読めてれば OK